### PR TITLE
Limit branch generation to even exponents

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ python3 collatz_tree.py --depth 10 -o collatz_tree.dot
 ```
 
 The depth option controls how many trunk nodes of the form `1 * 2^x` are
-included. Branches are automatically added from each trunk node to its
-corresponding `1 * (2^(2x))` value.
+included. Branches are only added from trunk nodes where `x` is even and at
+least `4` (starting with `16`). These branches connect to the value
+`1 * (2^(2x))` and are drawn horizontally to form right angles with the trunk.
 
 To render the resulting DOT file to an image you need Graphviz installed. For
 example:

--- a/collatz_tree.py
+++ b/collatz_tree.py
@@ -11,7 +11,12 @@ import argparse
 
 
 def generate_collatz_tree(max_depth: int) -> str:
-    """Return a DOT representation for the Collatz tree up to ``2**max_depth``."""
+    """Return a DOT representation for the Collatz tree up to ``2**max_depth``.
+
+    Branches are only added from trunk nodes where the exponent is even and at
+    least four (e.g. from 16, 64, 256, ...). Each branch points horizontally
+    toward its trunk node so that the edge forms a right angle with the trunk.
+    """
     lines = [
         "digraph CollatzTree {",
         "    graph [splines=line]",  # keep edges straight
@@ -28,11 +33,11 @@ def generate_collatz_tree(max_depth: int) -> str:
             # Edge direction toward 1
             lines.append(f'    "{node_val}" -> "{parent}"')
 
-    # Branches at right angles from trunk nodes
-    for x in range(1, max_depth + 1):
+    # Branches at right angles from trunk nodes with even exponent >= 4
+    for x in range(4, max_depth + 1, 2):
         trunk_val = 2 ** x
         branch_val = 2 ** (2 * x)
-        # Place branch horizontally to the right of the trunk
+        # Place branch horizontally to the right of the trunk at the same y
         lines.append(f'    "{branch_val}" [pos="{x},{x}!" label="{branch_val}"]')
         # Edge directed toward the trunk
         lines.append(f'    "{branch_val}" -> "{trunk_val}"')


### PR DESCRIPTION
## Summary
- only add branches when the trunk exponent is even and at least 4
- document new branch rules in README

## Testing
- `python3 -m py_compile collatz_tree.py`
- `python3 collatz_tree.py --depth 6 -o example.dot`

------
https://chatgpt.com/codex/tasks/task_e_6884abd5923c83219ed2d8a3b0ac5403